### PR TITLE
dockerによるmysqlの構築

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -14,7 +14,7 @@ default: &default
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password:
+  password: root
   host: localhost
 
 development:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.2'
+
+services:
+  database:
+    restart: always
+    image: mysql:5.7.32
+    ports:
+      - 3306:3306
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-datavolume:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+
+volumes:
+  mysql-datavolume:
+    driver: local


### PR DESCRIPTION
## 概要

- データベースの構築はDockerを使用した。
- MySQLはローカルにインストールされているverと合わせ、`mysql:5.7.32`を指定した。