### PR TITLE
フロントエンドの編集とweight_controllerの修正

### DIFF
--- a/app/controllers/api/v1/weights_controller.rb
+++ b/app/controllers/api/v1/weights_controller.rb
@@ -4,7 +4,11 @@ class Api::V1::WeightsController < Api::V1::ApiController
 
   # GET /weights
   def index
-    weights = Weight.where(user_id: current_user.id)
+    if params[:date]
+      weights = Weight.where(user_id: current_user.id, date: params[:date].in_time_zone.all_month)
+    else
+      weights = Weight.where(user_id: current_user.id, date: Time.current.all_month)
+    end
     render json: weights
   end
 

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,7 +34,7 @@ export const App: React.FC = () => {
       const res = await getCurrentUser();
       console.log(res);
 
-      if (res?.status === 200) {
+      if (res?.data.status === 200) {
         //もしresが存在していてstatusが200ならば、setIsSignedInでstateの値をtrueに更新する
         setIsSignedIn(true)
         //UserにcurrentUserの値をセット

--- a/frontend/src/components/main/Weight.tsx
+++ b/frontend/src/components/main/Weight.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from "react"
+import React, { useState, useEffect } from "react"
 
 import "date-fns"
 import DateFnsUtils from "@date-io/date-fns"
@@ -11,22 +11,21 @@ import {
 } from "@material-ui/pickers"
 
 
-import { AuthContext } from "../../App"
+
 import { WeightData } from "../../interfaces"
 import { createWeight } from "../../lib/api/weights"
 import { getWeights } from "../../lib/api/weights"
+import { Graph } from "components/utils/Graph"
 
 
 
 
 export const Weight = () => {
-  const { isSignedIn, currentUser } = useContext(AuthContext);
 
   const selectDate = new Date();
   const [ date, setDate ] = useState<Date | null>(selectDate);
   const [ kg, setKg ] = useState<string>("");
   const [ weights, setWeights ] = useState<WeightData []>([])
-  const [ newWeight, setNewWeight ] = useState<WeightData []>([])
   const [ loading, setLoading ] =useState<boolean>(true)
 
 
@@ -45,8 +44,8 @@ export const Weight = () => {
 
     setLoading(false)
   }
-  const weightItems = weights.map((weight) => {
-    return <li>{weight.kg}</li>
+  const weightItems = weights.map((weight, index) => {
+    return <li key={ index }>{weight.kg}</li>
   })
 
 
@@ -67,8 +66,7 @@ export const Weight = () => {
       const res = await createWeight(data);
       console.log(res);
 
-      setNewWeight(res.data)
-      indexWeights()
+      indexWeights();
 
     } catch (err) {
       console.log(err);
@@ -112,6 +110,7 @@ export const Weight = () => {
             >登録
             </Button>
             <span>{weightItems}</span>
+            <Graph />
           </>
         ) : (
           <></>

--- a/frontend/src/components/utils/Graph.tsx
+++ b/frontend/src/components/utils/Graph.tsx
@@ -10,10 +10,8 @@ import {
 
 import { getWeights } from "lib/api/weights"
 import { WeightData } from "interfaces";
-import { AuthContext } from "App"
 
 export const Graph = () => {
-  const { isSignedIn, currentUser } = useContext(AuthContext);
 
   const [ weights, setWeights ] = useState<WeightData []>([])
 
@@ -34,21 +32,19 @@ export const Graph = () => {
       console.log(err)
     }
   }
-  const weightItems = weights.map((weight) => {
-    return <li>{weight.kg}</li>
-  })
+  const weightItems = weights
 
   return (
     <>
-      {
-        isSignedIn && currentUser ? (
-          <>
-            <ul>{weightItems}</ul>
-          </>
-        ) : (
-          <></>
-        )
-      }
+      <Paper>
+        <Chart
+          data={weightItems}
+        >
+          <ArgumentAxis />
+          <ValueAxis />
+          <LineSeries valueField="kg" argumentField="date" />
+        </Chart>
+      </Paper>
     </>
   )
 }


### PR DESCRIPTION
## 概要

- graphの表示範囲
グラフの表示範囲は、1ヶ月のみとした。

- graphの表示範囲指定に伴うweights_controllerの編集
未実装であるが、1年間（その年の）のうち、月を指定することで、その月のデータを表示できるようにした。
デフォルトでは、現在の月のデータが表示される。

- devise_token_authの設定編集
リクエストごとにtokenを発行する設定を`false`にした。本来であれば、それぞれのリクエストごとにトークンを発行すべきであるが、個人開発で規模も小さいことからfalseとした。
ただし、トークン有効期間は2週間とした。