### PR TITLE
フロントエンドの編集

### DIFF
--- a/db/migrate/20210814124800_create_weights.rb
+++ b/db/migrate/20210814124800_create_weights.rb
@@ -2,7 +2,7 @@ class CreateWeights < ActiveRecord::Migration[6.1]
   def change
     create_table :weights do |t|
       t.date :date
-      t.integer :kg
+      t.float :kg
       t.references :user, null: false, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 2021_08_19_081834) do
 
   create_table "weights", charset: "utf8mb4", force: :cascade do |t|
     t.date "date"
-    t.integer "kg"
+    t.float "kg"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,8 +14,27 @@ users = [
 User.create!(users)
 
 weights = [
-  { date: "2021-8-30", kg: 62, user_id: 1 },
-  { date: "2021-8-31", kg: 63, user_id: 1 },
+  { date: "2021-8-30", kg: 62.5, user_id: 1 },
+  { date: "2021-8-31", kg: 63.1, user_id: 1 },
+  { date: "2021-9-1", kg: 63.5, user_id: 1 },
+  { date: "2021-9-2", kg: 63.1, user_id: 1 },
+  { date: "2021-9-3", kg: 63.4, user_id: 1 },
+  { date: "2021-9-4", kg: 63.5, user_id: 1 },
+  { date: "2021-9-5", kg: 64, user_id: 1 },
+  { date: "2021-9-6", kg: 64.5, user_id: 1 },
+  { date: "2021-9-7", kg: 65, user_id: 1 },
+  { date: "2021-9-8", kg: 64.5, user_id: 1 },
+  { date: "2021-9-9", kg: 64.5, user_id: 1 },
+  { date: "2021-9-10", kg: 65.5, user_id: 1 },
+  { date: "2021-9-11", kg: 64.5, user_id: 1 },
+  { date: "2021-9-12", kg: 64, user_id: 1 },
+  { date: "2021-9-13", kg: 63.5, user_id: 1 },
+  { date: "2021-9-14", kg: 63.5, user_id: 1 },
+  { date: "2021-9-15", kg: 64, user_id: 1 },
+  { date: "2021-9-16", kg: 64.5, user_id: 1 },
+  { date: "2021-9-17", kg: 64.5, user_id: 1 },
+  { date: "2021-9-18", kg: 64, user_id: 1 },
+  { date: "2021-9-19", kg: 63.5, user_id: 1 },
 ]
 
 Weight.create!(weights)

--- a/frontend/src/components/main/Weight.tsx
+++ b/frontend/src/components/main/Weight.tsx
@@ -9,13 +9,22 @@ import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker
 } from "@material-ui/pickers"
+import {
+  ArgumentAxis,
+  ValueAxis,
+  Chart,
+  SplineSeries,
+} from "@devexpress/dx-react-chart-material-ui";
+import { ArgumentScale, ValueScale } from '@devexpress/dx-react-chart';
+import Paper from '@material-ui/core/Paper';
 
 
 
-import { selectWeight, WeightData, WeightDate } from "../../interfaces"
+
+import { selectWeight, WeightData } from "../../interfaces"
 import { createWeight, deleteWeight } from "../../lib/api/weights"
 import { getWeights } from "../../lib/api/weights"
-import { Graph } from "components/utils/Graph"
+
 
 
 
@@ -27,6 +36,7 @@ export const Weight = () => {
   const [ kg, setKg ] = useState<string>("");
   const [ weights, setWeights ] = useState<selectWeight []>([])
   const [ loading, setLoading ] =useState<boolean>(true)
+
 
 
   const indexWeights = async () => {
@@ -45,9 +55,6 @@ export const Weight = () => {
 
     setLoading(false)
   }
-  const weightItems = weights.map((weight, index) => {
-    return <li key={ index }>{weight.kg}</li>
-  })
 
 
   const handleChange = (date: Date | null) => {
@@ -63,7 +70,7 @@ export const Weight = () => {
     }
 
     try {
-      const res = await deleteWeight(id);
+      const res = await deleteWeight(data.id);
       console.log(res);
 
       indexWeights();
@@ -142,7 +149,28 @@ export const Weight = () => {
                 )
               }
             </ul>
-            <Graph />
+            <Paper>
+              <Chart
+                data={weights}
+              >
+                <ValueScale name="kg" modifyDomain={()=>[0,100]}/>
+                <ArgumentAxis />
+                <ValueAxis scaleName="kg" showTicks/>
+                <SplineSeries valueField="kg" argumentField="date" scaleName="kg" />
+              </Chart>
+              <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                <KeyboardDatePicker
+                  label="登録年月日"
+                  format="MM/dd/yyyy"
+                  id="date-picker-dialog"
+                  value={date}
+                  onChange={handleChange}
+                  KeyboardButtonProps={{
+                    "aria-label": "change date"
+                  }}
+                />
+                </MuiPickersUtilsProvider>
+            </Paper>
           </>
         ) : (
           <></>

--- a/frontend/src/components/utils/Graph.tsx
+++ b/frontend/src/components/utils/Graph.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useContext, useEffect} from "react"
+import React, {useState, useEffect} from "react"
 import Paper from '@material-ui/core/Paper';
 
 import "date-fns"
@@ -8,24 +8,25 @@ import {
   ArgumentAxis,
   ValueAxis,
   Chart,
-  LineSeries,
+  SplineSeries,
+  Legend,
 } from "@devexpress/dx-react-chart-material-ui";
+import { ValueScale, Animation } from '@devexpress/dx-react-chart';
 import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker
 } from "@material-ui/pickers"
 
 import { getWeights } from "lib/api/weights"
-import { WeightData, WeightDate } from "interfaces";
+import { WeightData } from "interfaces";
+
+
 
 export const Graph = () => {
   const selectDate = new Date();
   const [ weights, setWeights ] = useState<WeightData []>([])
+  const [ maxWeight, setMaxWeight ] = useState<string>("")
   const [ date, setDate ] = useState<Date | null>(selectDate)
-
-  useEffect(() => {
-    indexWeights();
-  }, []);
 
   const handleChange = (date: Date | null) => {
     setDate(date);
@@ -44,17 +45,26 @@ export const Graph = () => {
       console.log(err)
     }
   }
-  const weightItems = weights
+
+  // setMaxWeight(weights.reduce((a,b) => a.kg > b.kg?a:b).kg)
+  // const modifyKgDomain = () => [0, parseFloat(maxWeight)+20]
+
+  useEffect(() => {
+    indexWeights();
+  }, []);
 
   return (
     <>
       <Paper>
         <Chart
-          data={weightItems}
+          data={weights}
         >
+          <ValueScale name="kg" modifyDomain={()=>[0,100]}/>
           <ArgumentAxis />
-          <ValueAxis />
-          <LineSeries valueField="kg" argumentField="date" />
+          <ValueAxis scaleName="kg" showGrid={false} showLine showTicks/>
+          <SplineSeries name="体重変化" valueField="kg" argumentField="date" scaleName="kg" />
+          <Animation />
+          <Legend />
         </Chart>
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
           <KeyboardDatePicker


### PR DESCRIPTION
## 概要

- 体重
小数点まで登録可能にするため、`float`を指定し、`rails:migrate:reset`を実行した

- グラフ縦軸
- 検討したこと
  - 最高体重＋10をMAX、-10をMIN=>グラフの変化率が乏しい。
  - defaultは逆に変化率が大きすぎて参考にならない

固定値0から100とした